### PR TITLE
Add __locations_input and entry_maker

### DIFF
--- a/lua/jj/files.lua
+++ b/lua/jj/files.lua
@@ -1,6 +1,7 @@
 local finders = require("telescope.finders")
 local pickers = require("telescope.pickers")
 local conf = require("telescope.config").values
+local make_entry = require("telescope.make_entry")
 local utils = require("jj.utils")
 
 return function(opts)
@@ -10,8 +11,10 @@ return function(opts)
     pickers
         .new(opts, {
             prompt_title = "Jujutsu Files",
+            __locations_input = true,
             finder = finders.new_table({
-                results = utils.get_os_command_output(cmd),
+            	results = utils.get_os_command_output(cmd),
+                entry_maker = opts.entry_maker or make_entry.gen_from_file(opts),
             }),
             previewer = conf.file_previewer(opts),
             sorter = conf.file_sorter(opts),


### PR DESCRIPTION
Why have `__locations_input`: https://github.com/nvim-telescope/telescope.nvim/commit/0bf09d05ab2968c6ec151cc8cdf24ad0012a46fb (it enables `path:row:col` syntax).

Why `make_entry`: This enables icons in file list.

![image](https://github.com/zschreur/telescope-jj.nvim/assets/2672503/d489e275-3713-4e4d-bc22-09e58e062fe3)

Before:

![image](https://github.com/zschreur/telescope-jj.nvim/assets/2672503/2d4272bf-22e7-4a3a-b351-0efa47efecd7)
