### PR TITLE
Fix conflicts so that it works when there are less than 3 spaces

### DIFF
--- a/lua/telescope-jj/conflicts.lua
+++ b/lua/telescope-jj/conflicts.lua
@@ -17,7 +17,7 @@ return function(opts)
     local results = {}
     for _, str in ipairs(cmd_output) do
         -- https://github.com/martinvonz/jj/blob/9a5b001d58353afb7ea6cb894c22d80878b811ae/cli/src/cli_util.rs#L1778
-        local word = string.match(str, "^(.-)%s%s%s")
+        local word = string.match(str, "^(.-)%s+%a+%-sided conflict$")
         table.insert(results, word)
     end
 

--- a/lua/telescope-jj/conflicts.test.lua
+++ b/lua/telescope-jj/conflicts.test.lua
@@ -1,0 +1,12 @@
+local s1 = "file two-sided conflict"
+local s2 = "file  two-sided conflict"
+local s3 = "file   two-sided conflict"
+local s4 = "file   three-sided conflict"
+local s5 = "file two-sided conflict two-sided conflict"
+
+local pattern = "^(.-)%s+%a+%-sided conflict$"
+assert(string.match(s1, pattern) == "file")
+assert(string.match(s2, pattern) == "file")
+assert(string.match(s3, pattern) == "file")
+assert(string.match(s4, pattern) == "file")
+assert(string.match(s5, pattern) == "file two-sided conflict")


### PR DESCRIPTION
The number of spaces separating the file name and conflict description is not always 3. This updates the conflict pattern match so that it can work with any number of spaces.