### PR TITLE
Remove end of string match from conflict regex

### DIFF
--- a/lua/telescope-jj/conflicts.lua
+++ b/lua/telescope-jj/conflicts.lua
@@ -17,7 +17,7 @@ return function(opts)
     local results = {}
     for _, str in ipairs(cmd_output) do
         -- https://github.com/martinvonz/jj/blob/9a5b001d58353afb7ea6cb894c22d80878b811ae/cli/src/cli_util.rs#L1778
-        local word = string.match(str, "^(.-)%s+%d+%-sided conflict$")
+        local word = string.match(str, "^(.-)%s+%d+%-sided conflict")
         table.insert(results, word)
     end
 

--- a/lua/telescope-jj/conflicts.test.lua
+++ b/lua/telescope-jj/conflicts.test.lua
@@ -2,11 +2,11 @@ local s1 = "file 2-sided conflict"
 local s2 = "file  2-sided conflict"
 local s3 = "file   2-sided conflict"
 local s4 = "file   3-sided conflict"
-local s5 = "file 2-sided conflict 2-sided conflict"
+local s5 = "file 2-sided conflict including 1 deletion"
 
-local pattern = "^(.-)%s+%d+%-sided conflict$"
+local pattern = "^(.-)%s+%d+%-sided conflict"
 assert(string.match(s1, pattern) == "file")
 assert(string.match(s2, pattern) == "file")
 assert(string.match(s3, pattern) == "file")
 assert(string.match(s4, pattern) == "file")
-assert(string.match(s5, pattern) == "file 2-sided conflict")
+assert(string.match(s5, pattern) == "file")


### PR DESCRIPTION
If there is a deletion the conflict message has additional content at the end of it. This solves the case for when the message is of the format:
```
file 2-sided conflict including 1 deletion
```